### PR TITLE
add context examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This repository is dedicated to providing training materials and examples for un
 2. [Channels](./channel_examples): This package provides examples of using channels for communication between goroutines. It covers both unbuffered and buffered channels.
 
 3. [Select](./select_examples): This package provides examples of using select statements to control concurrent execution. It covers both the basic syntax and some common patterns.
- 
+   
+4. [Context](./context_examples): This package provides examples of using context. 
 
 ## Getting Started
 

--- a/context_examples/main.go
+++ b/context_examples/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// TimedTask simulates a task that takes time to complete. It respects context timeout.
+func TimedTask(ctx context.Context) {
+	// Simulating a long-running task
+	operation := func() {
+		for i := 0; i < 10; i++ {
+			if ctx.Err() != nil {
+				fmt.Printf("Task interrupted, err: %v.\n", ctx.Err())
+				return
+			}
+			fmt.Printf("Working (%d/10).\n", i+1)
+			time.Sleep(1 * time.Second)
+		}
+		fmt.Println("Task completed successfully")
+	}
+
+	select {
+	case <-ctx.Done():
+		fmt.Printf("Operation cancelled, err: %v.\n", ctx.Err())
+	case <-func() <-chan struct{} {
+		ch := make(chan struct{})
+		go func() {
+			defer close(ch)
+			operation()
+		}()
+		return ch
+	}():
+	}
+}
+
+func main() {
+	// Create a context that cancels automatically after a 5-second timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Run the timed task with the context.
+	TimedTask(ctx)
+}

--- a/select_examples/select.go
+++ b/select_examples/select.go
@@ -47,6 +47,8 @@ func (r *receiver) receive(c chan string, stop, stopped chan struct{}) {
 	}
 }
 
+// drain drains the messages in the channel
+// always think draining remaning tasks, messsages when to process is about stop in asynchronous programming
 func (r *receiver) drain(c chan string) {
 	for {
 		select {

--- a/select_examples/select_test.go
+++ b/select_examples/select_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestMessageReaderAndWriterN(t *testing.T) {
+func TestReceive(t *testing.T) {
 	tests := []struct {
 		desc string
 		n    int


### PR DESCRIPTION
### What changed?
Context example added.

### Why?
To show how timeout can be handled in a chain of Goroutines. 

### How is it tested?
Tested via running the code directly from command prompt.
```
cd context_examples/
go run main.go
```
